### PR TITLE
Create Selectable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,24 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 3.0
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*_spec.rb
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Max: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [Unreleased]
+
+## [0.1.0] - 2023-08-18
+
+- Initial release

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at TODO: Write your email address. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in selectable.gemspec
+gemspec
+
+group :test, :development do
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.0"
+  gem "rubocop", "~> 1.21"
+  gem "rubocop-rake", "~> 0.6.0"
+  gem "rubocop-rspec", "~> 2.24"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,75 @@
+PATH
+  remote: .
+  specs:
+    selectable (0.1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    base64 (0.1.1)
+    diff-lcs (1.5.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.8.1)
+    rexml (3.2.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    rubocop (1.56.2)
+      base64 (~> 0.1.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.3)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-capybara (2.19.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.24.0)
+      rubocop (~> 1.33)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.24.1)
+      rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.4.2)
+
+PLATFORMS
+  arm64-darwin-22
+
+DEPENDENCIES
+  rake (~> 13.0)
+  rspec (~> 3.0)
+  rubocop (~> 1.21)
+  rubocop-rake (~> 0.6.0)
+  rubocop-rspec (~> 2.24)
+  selectable!
+
+BUNDLED WITH
+   2.4.19

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 TODO: Write your name
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,109 @@
+# Selectable
+
+Selectable aims to help match dynamic input to modular code that was written to handle specific use cases. In a nutshell, you can think of Selectable as a more powerful and dynamic case statement where functionality can be added without having to curate a list of when clauses.
+
+Please use caution when using this gem. While it should be safe in most cases, there is inherently risk associated with accepting somewhat arbitrary user input.
+
+## Installation
+
+Pull down the repo from github. In the project root execute the following commands to install dependencies, build the gem, and install it:
+
+```
+bundle install
+gem build
+gem install <gemfilefrombuild>
+```
+
+## Usage
+
+Basic usage:
+
+```
+s = Selectable.new(namespace: MyModules)
+selected_module = s.for('input_string')
+```
+
+### Complete Example
+
+Create a YAML file with the following contents:
+
+```
+---
+services:
+  service_1:
+    config:
+      option1: value1
+  service_2:
+    config:
+      option2: value2
+  service_3:
+    config:
+      option3: value3
+```
+
+
+
+```
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "selectable"
+require "yaml"
+
+module MyModules
+  module ModuleHandler
+    def self.selectable_for
+      ["service_1"]
+    end
+
+    def self.process(config)
+      puts "Processing #{config}"
+    end
+  end
+end
+
+module MyModules
+  class ClassHandler
+    def self.selectable_for
+      ["service_2"]
+    end
+
+    def process(config)
+      puts "Processing #{config}"
+    end
+  end
+end
+
+services = YAML.safe_load(File.read('service_config.yml'))
+
+s = Selectable.new(namespace: MyModules)
+puts "The following inputs are selectable:"
+puts s.selectors.inspect
+puts
+
+services["services"].each do |service, config|
+  puts "Is #{service} selectable: #{s.selectable?(service)}"
+  if s.selectable?(service)
+    processor = s.for(service).respond_to?(:new) ? s.for(service).new : s.for(service)
+    processor.process(config)
+  end
+end
+```
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `selectable.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/erickcantwell/selectable. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/erickcantwell/selectable/blob/main/CODE_OF_CONDUCT.md).
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+## Code of Conduct
+
+Everyone interacting in the Selectable project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/erickcantwell/selectable/blob/main/CODE_OF_CONDUCT.md).

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+require "rubocop/rake_task"
+
+RuboCop::RakeTask.new
+
+task default: %i[spec rubocop]

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "selectable"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/selectable.rb
+++ b/lib/selectable.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class Error < StandardError; end
+class UnSelectable < StandardError; end
+
+# Selectable: Help load classes and modules for a specific use case based
+# on user input
+#
+# Attributes:
+#   namespace: A module or class namespace to load
+#   downcase: Whether or not to downcase inputs.
+#     Default: true
+class Selectable
+  VERSION = "0.1.1"
+
+  attr_reader :namespace, :downcase
+
+  def initialize(namespace: nil, downcase: true)
+    @namespace = namespace
+    @downcase = downcase
+  end
+
+  # Returns an array of selectable modules and classes from the namespace
+  # provided
+  #
+  # For convenience, it will coerce
+  def selectable
+    return @selectable if @selectable
+
+    selector_data = {}
+    namespace.constants.each do |c|
+      selector = namespace.const_get(c)
+      next unless can_be_selected(selector)
+
+      s = selector.selectable_for
+      raise Error, "selectable_for must be an array in #{selector}" unless s.is_a?(Array)
+
+      s.each { |x| x.downcase! if can_downcase(x) }
+      selector_data[selector] = s
+    end
+    @selectable = selector_data
+  end
+
+  def selectors
+    selectable.values.flatten
+  end
+
+  def selectable?(object)
+    object.downcase! if can_downcase(object)
+    return true if selectors.include?(object)
+
+    false
+  end
+
+  def for(thing)
+    selectable.each do |obj, values|
+      thing.downcase! if can_downcase(thing)
+      return obj if values.include?(thing)
+    end
+
+    raise UnSelectable, "#{thing} is unselectable"
+  end
+
+  private
+
+  def can_be_selected(obj)
+    (obj.is_a?(Module) || obj.is_a?(Class)) && obj.respond_to?(:selectable_for)
+  end
+
+  def can_downcase(obj)
+    downcase && obj.respond_to?(:downcase) && !obj.frozen?
+  end
+end

--- a/selectable.gemspec
+++ b/selectable.gemspec
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "lib/selectable"
+
+Gem::Specification.new do |spec|
+  spec.name = "selectable"
+  spec.version = Selectable::VERSION
+  spec.authors = ["Erick Cantwell"]
+  spec.email = ["erick@erickcantwell.com"]
+
+  spec.summary = "Create arbitrary selectable classes and modules"
+  spec.description = "Load all of the classes and modules in a namespace so that they are selectable"
+  spec.homepage = "https://www.erickcantwell.com"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.0"
+
+  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://somesourcecodeuri.com"
+  spec.metadata["changelog_uri"] = "https://somesourcecodeuri.com/CHANGELOG.md"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git .circleci appveyor Gemfile])
+    end
+  end
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  # Uncomment to register a new dependency of your gem
+  # spec.add_dependency "example-gem", "~> 1.0"
+
+  # For more information and examples about making a new gem, check out our
+  # guide at: https://bundler.io/guides/creating_gem.html
+end

--- a/sig/selectable.rbs
+++ b/sig/selectable.rbs
@@ -1,0 +1,4 @@
+module Selectable
+  VERSION: String
+  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+end

--- a/spec/selectable_spec.rb
+++ b/spec/selectable_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Test Modules
+module Tester
+  class StringTestClass
+    def self.selectable_for
+      ["strings"]
+    end
+  end
+
+  class FloatTestClass
+    def self.selectable_for
+      [Float]
+    end
+  end
+
+  class NotSelectable
+  end
+
+  module IntegerTestModule
+    def self.selectable_for
+      [Integer, 3]
+    end
+  end
+end
+
+module MisconfiguredTester
+  module NotArray
+    def self.selectable_for
+      "notanarray"
+    end
+  end
+end
+
+RSpec.describe Selectable do
+  it "has a version number" do
+    expect(Selectable::VERSION).not_to be nil
+  end
+
+  describe "#selectable" do
+    it "raises an exception if the selectable class or module is misconfigured" do
+      s = described_class.new(namespace: MisconfiguredTester)
+      expect do
+        s.selectable
+      end.to raise_error(StandardError, "selectable_for must be an array in MisconfiguredTester::NotArray")
+    end
+
+    it "returns a hash of selectable objects" do
+      s = described_class.new(namespace: Tester)
+      expect(s.selectable).to include({ Tester::StringTestClass => ["strings"],
+                                        Tester::FloatTestClass => [Float],
+                                        Tester::IntegerTestModule => [Integer, 3] })
+    end
+  end
+
+  describe "#selectors" do
+    it "returns a flattened list of all selectors" do
+      s = described_class.new(namespace: Tester)
+      expect(s.selectors).to contain_exactly("strings", Float, Integer, 3)
+    end
+  end
+
+  describe "#selectable?" do
+    it "returns true for a selector that exists" do
+      s = described_class.new(namespace: Tester)
+      expect(s.selectable?("strings")).to be true
+    end
+
+    it "returns false for a selector that does not exist" do
+      s = described_class.new(namespace: Tester)
+      expect(s.selectable?("randothing")).to be false
+    end
+  end
+
+  describe "#for" do
+    it "raises an exception if the input is unselectable" do
+      s = described_class.new(namespace: Tester)
+      expect do
+        s.for("badinput")
+      end.to raise_error(UnSelectable, "badinput is unselectable")
+    end
+
+    it "returns the selected class for 'strings' input" do
+      s = described_class.new(namespace: Tester)
+      expect(s.for("strings").new).to be_a(Tester::StringTestClass)
+    end
+
+    it "returns the selected module for 'Integer' input" do
+      s = described_class.new(namespace: Tester)
+      expect(s.for(Integer)).to eq(Tester::IntegerTestModule)
+    end
+
+    it "returns the selected module for 'Float' input" do
+      s = described_class.new(namespace: Tester)
+      expect(s.for(Float).new).to be_a(Tester::FloatTestClass)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "selectable"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
Initial commit of a Ruby gem that can be used for creating a list of selectable classes or modules. Can potentially be useful for replacing the need to create complicated input handlers when the inputs might not be known